### PR TITLE
fix: typo on the curl command

### DIFF
--- a/pingfederate/opt/liveness.sh
+++ b/pingfederate/opt/liveness.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 URL="https://localhost:${PF_ENGINE_PORT}/pf/heartbeat.ping"
 test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE" && URL="https://localhost:${PF_ADMIN_PORT}/pingfederate/app"
-curl -ssk -o /dev/null "${URL}"
+curl -sSk -o /dev/null "${URL}"
 if test ${?} -ne 0 ; then
     # the health check must return 0 for healthy, 1 otherwise
     # but not any other code so we catch the curl return code and


### PR DESCRIPTION
# Summary
The liveness check command uses several parameters to configure the output of the curl command.
It seems one of the parameter should be in upper case in order to serve a purpose.

# cURL parameter explanation
-s: silent
-S: show-errors

# Reference
https://curl.haxx.se/docs/manpage.html#-S