### PR TITLE
add opt to preserve docker env

### DIFF
--- a/ci_scripts/ci_tools.lib.sh
+++ b/ci_scripts/ci_tools.lib.sh
@@ -715,7 +715,10 @@ else
     #we are on local
     IS_LOCAL_BUILD=true
     export IS_LOCAL_BUILD
-    FOUNDATION_REGISTRY="pingidentity"
+
+    if [ ! -z ${FOUNDATION_REGISTRY} ]; then
+        FOUNDATION_REGISTRY="pingidentity"
+    fi
     DEPS_REGISTRY="${DEPS_REGISTRY_OVERRIDE}"
     gitBranch=$(git rev-parse --abbrev-ref HEAD)
     GIT_REV_SHORT=$(git rev-parse --short=4 HEAD)

--- a/ci_scripts/serial_build.sh
+++ b/ci_scripts/serial_build.sh
@@ -38,6 +38,8 @@ Usage: ${0} {options}
         verbose docker build not using docker buildkit
     --with-tests
         Execute smoke tests
+    -n, --no-clean
+        does not clean up and remove existing docker containers/images
     --help
         Display general usage information
 END_USAGE
@@ -88,6 +90,9 @@ while ! test -z "${1}"; do
             test -z "${1}" && usage "You must provide a version to build"
             versionsToBuild="${versionsToBuild:+${versionsToBuild} }--version ${1}"
             ;;
+        -n | --no-clean)
+            _noClean=true
+            ;;
         --with-tests)
             _smokeTests=true
             ;;
@@ -112,8 +117,11 @@ CI_SCRIPTS_DIR="${CI_PROJECT_DIR:-.}/ci_scripts"
 # shellcheck source=./ci_tools.lib.sh
 . "${CI_SCRIPTS_DIR}/ci_tools.lib.sh"
 
-"${CI_SCRIPTS_DIR}/cleanup_docker.sh" full
-test "${?}" -ne 0 && exit 1
+if test -z "${_noClean}"; then
+    "${CI_SCRIPTS_DIR}/cleanup_docker.sh" full
+    test "${?}" -ne 0 && exit 1
+fi
+
 # Word-split is expected behavior for $jvmsToBuild and $shimsToBuild. Disable shellcheck.
 # shellcheck disable=SC2086
 "${CI_SCRIPTS_DIR}/build_foundation.sh" ${jvmsToBuild} ${shimsToBuild}


### PR DESCRIPTION
When building the docker images locally, there are instances where I do _not_ want to delete all other docker containers and images on my docker build host. This adds a '-n' option to the serial_build.sh script to not call `cleanup_docker.sh full`. 