### PR TITLE
jq bug with hyphens

### DIFF
--- a/pingcommon/opt/staging/hooks/pingsecrets.lib.sh
+++ b/pingcommon/opt/staging/hooks/pingsecrets.lib.sh
@@ -133,7 +133,7 @@ process_secrets_env_json() {
         echo "     --> ${_secretEnvFile} (env property file)"
 
         for key in $(jq -r "keys | flatten[]" "${_secretJson}"); do
-            echo "$key=$(jq ".$key" "${_secretJson}")" >> "${_secretEnvFile}"
+            echo "$key=$(jq '."$key"' "${_secretJson}")" >> "${_secretEnvFile}"
         done
 
         mv "${_secretJson}" "${_secretJson}".PROCESSED


### PR DESCRIPTION
During the initailization of the pingdirectory containers, I saw:
`
Processing secrets in SECRETS_DIR (if any)...
  /run/secrets/password.env.json
     --> /run/secrets/password.env (env property file)
jq: error: user/0 is not defined at <top-level>, line 1:
.admin-user-password
jq: error: password/0 is not defined at <top-level>, line 1:
.admin-user-password
jq: 2 compile errors
jq: error: password/0 is not defined at <top-level>, line 1:
.encryption-password
jq: 1 compile error
jq: error: user/0 is not defined at <top-level>, line 1:
.root-user-password
jq: error: password/0 is not defined at <top-level>, line 1:
.root-user-password
jq: 2 compile errors
mv: can't rename '/run/secrets/password.env.json': Operation not permitted
  /run/secrets/password.env.json
     --> /run/secrets/admin-user-password
     --> /run/secrets/encryption-password
     --> /run/secrets/root-user-password
`

This PR adds some additional quotes around the jq of the key, if there are '-'s in the key, it'll error out.

 