### PR TITLE
Feature/expose additional docker port

### DIFF
--- a/pingfederate/Dockerfile
+++ b/pingfederate/Dockerfile
@@ -341,6 +341,11 @@ ENV SHIM=${SHIM} \
 #-- PF_RUN_PF_HTTPS_PORT will override this for PingFederate 11.3 and later.
     PF_ENGINE_PORT=9031 \
 
+#-- Defines a secondary HTTPS port that can be used for mutual SSL/TLS 
+#-- (client X.509 certificate) authentication for both end users and protocol requests
+#-- PF_RUN_PF_HTTPS_SECONDARY_PORT will override this value. Set to -1 to disable port by default to reduce attack surface.
+    PF_ENGINE_SECONDARY_PORT=-1 \
+
 #-- Flag to turn on PingFederate Engine debugging
 #-- Used in run.sh
     PF_ENGINE_DEBUG=false \

--- a/pingfederate/Dockerfile
+++ b/pingfederate/Dockerfile
@@ -512,7 +512,7 @@ LABEL name="${PING_PRODUCT}" \
       summary="PingFederate is an enterprise federation server and identity bridge for user authentication and standards-based single sign-on (SSO) for employee, partner, and customer identity types." \
       description="PingFederate enables outbound and inbound solutions for SSO, federated identity management, customer identity and access management, mobile identity security, API security, and social identity integration. Browser-based SSO extends employee, customer, and partner identities across domains without passwords using standard identity protocols, such as SAML, WS-Federation, WS-Trust, OAuth, OpenID Connect (OIDC), and System for Cross-domain Identity Management (SCIM)."
 
-EXPOSE 9031 9999
+EXPOSE 9031 9032 9999
 
 WORKDIR ${BASE}
 

--- a/pingfederate/opt/build.sh.post
+++ b/pingfederate/opt/build.sh.post
@@ -30,6 +30,7 @@ sed -i -e 's/^pf\.admin\.https\.port=.*$/pf.admin.https.port=${PF_ADMIN_PORT}/' 
     -e 's/^pf\.console\.authentication=.*$/pf.console.authentication=${PF_CONSOLE_AUTHENTICATION}/' \
     -e 's/^pf\.admin\.api\.authentication=.*$/pf.admin.api.authentication=${PF_ADMIN_API_AUTHENTICATION}/' \
     -e 's/^pf\.https\.port=.*$/pf.https.port=${PF_ENGINE_PORT}/' \
+    -e 's/^pf\.secondary\.https\.port=.*$/pf.secondary.https.port=${PF_ENGINE_SECONDARY_PORT}/' \    
     -e 's/^pf\.heartbeat\.system\.monitoring=false/pf.heartbeat.system.monitoring=true/' \
     -e 's/^pf\.operational\.mode=.*$/pf.operational.mode=${OPERATIONAL_MODE}/' \
     -e 's/^pf\.cluster\.tcp\.discovery\.initial\.hosts=.*$/pf.cluster.tcp.discovery.initial.hosts=${DISCOVERY_INITIAL_HOST}/' \

--- a/pingfederate/opt/staging/hooks/04-check-variables.sh.pre
+++ b/pingfederate/opt/staging/hooks/04-check-variables.sh.pre
@@ -34,6 +34,13 @@ if test -n "${PF_RUN_PF_HTTPS_PORT}"; then
     PF_ENGINE_PORT="${PF_RUN_PF_HTTPS_PORT}"
 fi
 
+# PF_ENGINE_SECONDAY_PORT overriden by PF_RUN_PF_HTTPS_SECONDARY_PORT
+if test -n "${PF_RUN_PF_HTTPS_SECONDARY_PORT}"; then
+    # shellcheck disable=SC2034
+    PF_ENGINE_SECONDAY_PORT="${PF_RUN_PF_HTTPS_SECONDARY_PORT}"
+fi
+
+
 # OPERATIONAL_MODE overriden by PF_RUN_PF_OPERATIONAL_MODE
 if test -n "${PF_RUN_PF_OPERATIONAL_MODE}"; then
     # shellcheck disable=SC2034


### PR DESCRIPTION
In mTLS and client authentication configurations, PingFederate requires the use of secondary port. 

https://docs.pingidentity.com/r/en-us/pingfederate-120/pf_config_x509_certific_idp_adapt
https://docs.pingidentity.com/r/en-us/pingfederate-120/pf_config_pf_propert

This PR updates the docker build to expose the new port and add an override ENV variable to configure secondary port. 

I am unable to test locally since I don't have access build container without ARGs to artificatory, which I assume is gated. 

