### PR TITLE
Active/passive PF Admin hooks

### DIFF
--- a/helm-tests/integration-tests/.gitlab-ci.yml
+++ b/helm-tests/integration-tests/.gitlab-ci.yml
@@ -755,4 +755,86 @@ arm.paz-pd.v2:
 #         - .gitlab-ci.yml
 #       when: on_success
 #     - if: '$CI_PIPELINE_SOURCE =~ /^schedule$|^web$/'
+
+################################################
+# The purpose of the integration test below is
+# to verify the PingFederate active/passive multi-admin
+# hook logic on the x86_64 runner
+intel.pf-multi-admin.v1:
+  stage: test.integration
+  script:
+    - ci_scripts/run_helm_integration.sh --integration-test pf-multi-admin --variation 1
+  retry: 1
+  variables:
+    KUBERNETES_CPU_REQUEST: 2850m
+    KUBERNETES_CPU_LIMIT: 2850m
+    KUBERNETES_MEMORY_REQUEST: 5880000000
+    KUBERNETES_MEMORY_LIMIT: 5880000000
+    KUBERNETES_POLL_TIMEOUT: 30m
+  rules:
+    - if: $ARCHIVE_PIPELINE == "true"
+      when: never
+    - if: $CUSTOM_IMAGE_PIPELINE == "true"
+      when: never
+    - if: '$CI_COMMIT_MESSAGE =~ /\[skip build\]|\[skip products\]|\[skip tests\]|\[skip integration\]/i'
+      when: never
+    - if: '$BUILD_PRODUCT != null && $BUILD_PRODUCT =~ /(?:^|,)pingfederate(?:$|,)/i'
+      when: on_success
+    - if: '$BUILD_PRODUCT != null'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE =~ /^push$/'
+      changes:
+        - helm-tests/integration-tests/pf-multi-admin/*
+        - pingbase/**/*
+        - pingcommon/**/*
+        - pingfederate/**/*
+        - ci_scripts/*
+        - pingjvm/*
+        - .gitlab-ci.yml
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE =~ /^schedule$|^web$/'
+      when: on_success
+
+################################################
+# The purpose of the integration test below is
+# to verify the PingFederate active/passive multi-admin
+# hook logic on the aarch64 runner
+arm.pf-multi-admin.v2:
+  stage: test.integration
+  image: $RUNNER_IMAGE_AARCH64
+  #image: $RUNNER_IMAGE_AARCH64_TEST
+  tags:
+    - platform=aarch64
+  script:
+    - ci_scripts/run_helm_integration.sh --integration-test pf-multi-admin --variation 2
+  retry: 1
+  variables:
+    KUBERNETES_CPU_REQUEST: 2850m
+    KUBERNETES_CPU_LIMIT: 2850m
+    KUBERNETES_MEMORY_REQUEST: 5880000000
+    KUBERNETES_MEMORY_LIMIT: 7840000000
+    KUBERNETES_POLL_TIMEOUT: 30m
+  rules:
+    - if: $ARCHIVE_PIPELINE == "true"
+      when: never
+    - if: $CUSTOM_IMAGE_PIPELINE == "true"
+      when: never
+    - if: '$CI_COMMIT_MESSAGE =~ /\[skip build\]|\[skip products\]|\[skip tests\]|\[skip integration\]/i'
+      when: never
+    - if: '$BUILD_PRODUCT != null && $BUILD_PRODUCT =~ /(?:^|,)pingfederate(?:$|,)/i'
+      when: on_success
+    - if: '$BUILD_PRODUCT != null'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE =~ /^push$/'
+      changes:
+        - helm-tests/integration-tests/pf-multi-admin/*
+        - pingbase/**/*
+        - pingcommon/**/*
+        - pingfederate/**/*
+        - ci_scripts/*
+        - pingjvm/*
+        - .gitlab-ci.yml
+      when: on_success
+    - if: '$CI_PIPELINE_SOURCE =~ /^schedule$|^web$/'
+      when: on_success
 #       when: on_success

--- a/helm-tests/integration-tests/integration-tests.json
+++ b/helm-tests/integration-tests/integration-tests.json
@@ -551,6 +551,38 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "pf-multi-admin",
+            "directory": "pf-multi-admin",
+            "variations": [
+                {
+                    "id": "1",
+                    "architecture": "x86_64",
+                    "platform": "EKS",
+                    "products": [
+                        {
+                            "productName": "pingfederate-admin",
+                            "version": "latest",
+                            "shim": "alpine:3.23.4",
+                            "jvm": "al17"
+                        }
+                    ]
+                },
+                {
+                    "id": "2",
+                    "architecture": "aarch64",
+                    "platform": "EKS",
+                    "products": [
+                        {
+                            "productName": "pingfederate-admin",
+                            "version": "latest",
+                            "shim": "alpine:3.23.4",
+                            "jvm": "al17"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-failover.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-failover.yaml
@@ -1,0 +1,127 @@
+###############################################################################
+# Ping Identity Test - PingFederate Multi-Admin: Pod-0 Restart After Failover
+#
+# Variation 1 (intel) / Variation 2 (arm)
+# Asserts that pod-0 does not self-promote when it restarts after a failover:
+#   - Start two-node cluster; admin-0 becomes active
+#   - Promote admin-1 to active via cluster API
+#   - Delete (restart) admin-0 pod
+#   - Wait for admin-0 to come back
+#   - Assert cluster still has exactly 1 ACTIVE (admin-1) and admin-0 is PASSIVE
+###############################################################################
+pingfederate-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingfederate
+    OPERATIONAL_MODE: CLUSTERED_CONSOLE
+    PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "true"
+  workload:
+    type: StatefulSet
+    statefulSet:
+      podManagementPolicy: OrderedReady
+      persistentvolume:
+        enabled: false
+  container:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+
+###############################################################################
+# Test Steps
+###############################################################################
+testFramework:
+  enabled: true
+  testConfigMaps:
+    files:
+      - wait-for-url.sh
+
+  testSteps:
+    - name: 01-wait-for-admin-0-active
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - /var/run/wait-for-url.sh
+        - https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true
+        - "900"
+
+    - name: 02-promote-admin-1
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Promoting admin-1 to active..."
+          CODE=$(curl -sk -o /tmp/promote.out -w '%{http_code}' \
+            -X POST \
+            -u "administrator:${PING_IDENTITY_PASSWORD}" \
+            -H "X-XSRF-Header: PingFederate" \
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/adminNode/role/active")
+          echo "Promote response (HTTP ${CODE}):"
+          cat /tmp/promote.out
+          if test "${CODE}" != "200"; then
+            echo "FAIL: promote returned HTTP ${CODE}"
+            exit 1
+          fi
+          echo "PASS: admin-1 promoted to active"
+
+    - name: 03-delete-admin-0-pod
+      image: bitnami/kubectl:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Deleting admin-0 pod to simulate restart..."
+          kubectl delete pod "${PF_ADMIN_PRIVATE_HOSTNAME}-0" --wait=false
+          echo "Pod deleted."
+
+    - name: 04-wait-for-admin-0-back
+      image: bitnami/kubectl:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for admin-0 pod to be Running again..."
+          kubectl wait pod "${PF_ADMIN_PRIVATE_HOSTNAME}-0" \
+            --for=condition=Ready \
+            --timeout=600s
+          echo "admin-0 is Ready."
+
+    - name: 05-assert-admin-1-still-active
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          STATUS=$(curl -sk -u "administrator:${PING_IDENTITY_PASSWORD}" \
+            -H "X-XSRF-Header: PingFederate" \
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/status")
+          ACTIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"ACTIVE"' | wc -l | tr -d ' ')
+          echo "Active node count: ${ACTIVE}"
+          if test "${ACTIVE}" != "1"; then
+            echo "FAIL: expected exactly 1 ACTIVE, got ${ACTIVE}"
+            echo "${STATUS}"
+            exit 1
+          fi
+          ADMIN1_ROLE=$(echo "${STATUS}" | grep -o '"consoleRole":"[A-Z]*"' | tail -1 | grep -o '[A-Z]*"' | tr -d '"')
+          echo "admin-1 role in status: ${ADMIN1_ROLE}"
+          CODE=$(curl -sk -o /dev/null -w '%{http_code}' \
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
+          echo "admin-1 heartbeat?checkActive=true: HTTP ${CODE}"
+          if test "${CODE}" != "200"; then
+            echo "FAIL: admin-1 heartbeat returned ${CODE}, expected 200 (active)"
+            exit 1
+          fi
+          CODE0=$(curl -sk -o /dev/null -w '%{http_code}' \
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
+          echo "admin-0 heartbeat?checkActive=true: HTTP ${CODE0}"
+          if test "${CODE0}" != "403"; then
+            echo "FAIL: admin-0 heartbeat returned ${CODE0}, expected 403 (passive)"
+            exit 1
+          fi
+          echo "PASS: admin-1 is active (200), admin-0 is passive (403)"

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-failover.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-failover.yaml
@@ -7,14 +7,21 @@
 #   - Promote admin-1 to active via cluster API
 #   - Delete (restart) admin-0 pod
 #   - Wait for admin-0 to come back
-#   - Assert cluster still has exactly 1 ACTIVE (admin-1) and admin-0 is PASSIVE
+#   - Assert admin-1 still responds 200 on ?checkActive=true, admin-0 returns 403
+#
+# Pod DNS:  <pod>.<release>-pingfederate-cluster  (headless service)
+# PF_ADMIN_PRIVATE_HOSTNAME = <release>-pingfederate-admin
+# Headless svc              = <release>-pingfederate-cluster
 ###############################################################################
+global:
+  envs:
+    PING_IDENTITY_PASSWORD: 2FederateM0re
+
 pingfederate-admin:
   enabled: true
   envs:
-    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: getting-started/pingfederate
     OPERATIONAL_MODE: CLUSTERED_CONSOLE
+    CREATE_INITIAL_ADMIN_USER: "true"
     PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "true"
   workload:
     type: StatefulSet
@@ -46,22 +53,58 @@ testFramework:
       image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
-        - /var/run/wait-for-url.sh
-        - https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true
-        - "900"
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          URL="https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true"
+          echo "Waiting for active admin-0: ${URL}"
+          i=0
+          while test "${i}" -lt 900; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 2 "${URL}" 2>/dev/null)
+            if test "${CODE}" = "200"; then echo "PASS: admin-0 is active"; exit 0; fi
+            echo "${i}: Response: ${CODE}"
+            sleep 2
+            i=$((i + 1))
+          done
+          echo "FAIL: admin-0 did not become active within timeout"
+          exit 1
 
-    - name: 02-promote-admin-1
+    - name: 02-wait-for-admin-1-passive
       image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c
         - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          URL="https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping"
+          echo "Waiting for admin-1 to be reachable: ${URL}"
+          i=0
+          while test "${i}" -lt 450; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 2 "${URL}" 2>/dev/null)
+            if test "${CODE}" = "200" || test "${CODE}" = "403"; then
+              echo "PASS: admin-1 is reachable (HTTP ${CODE})"
+              exit 0
+            fi
+            echo "${i}: Response: ${CODE}"
+            sleep 2
+            i=$((i + 1))
+          done
+          echo "FAIL: admin-1 did not become reachable within timeout"
+          exit 1
+
+    - name: 03-promote-admin-1
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
           echo "Promoting admin-1 to active..."
           CODE=$(curl -sk -o /tmp/promote.out -w '%{http_code}' \
             -X POST \
             -u "administrator:${PING_IDENTITY_PASSWORD}" \
             -H "X-XSRF-Header: PingFederate" \
-            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/adminNode/role/active")
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/adminNode/role/active")
           echo "Promote response (HTTP ${CODE}):"
           cat /tmp/promote.out
           if test "${CODE}" != "200"; then
@@ -70,8 +113,8 @@ testFramework:
           fi
           echo "PASS: admin-1 promoted to active"
 
-    - name: 03-delete-admin-0-pod
-      image: bitnami/kubectl:latest
+    - name: 04-delete-admin-0-pod
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c
@@ -80,48 +123,56 @@ testFramework:
           kubectl delete pod "${PF_ADMIN_PRIVATE_HOSTNAME}-0" --wait=false
           echo "Pod deleted."
 
-    - name: 04-wait-for-admin-0-back
-      image: bitnami/kubectl:latest
-      command:
-        - /bin/sh
-        - -c
-        - |
-          echo "Waiting for admin-0 pod to be Running again..."
-          kubectl wait pod "${PF_ADMIN_PRIVATE_HOSTNAME}-0" \
-            --for=condition=Ready \
-            --timeout=600s
-          echo "admin-0 is Ready."
-
-    - name: 05-assert-admin-1-still-active
+    - name: 05-wait-for-admin-0-back
       image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c
         - |
-          STATUS=$(curl -sk -u "administrator:${PING_IDENTITY_PASSWORD}" \
-            -H "X-XSRF-Header: PingFederate" \
-            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/status")
-          ACTIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"ACTIVE"' | wc -l | tr -d ' ')
-          echo "Active node count: ${ACTIVE}"
-          if test "${ACTIVE}" != "1"; then
-            echo "FAIL: expected exactly 1 ACTIVE, got ${ACTIVE}"
-            echo "${STATUS}"
-            exit 1
-          fi
-          ADMIN1_ROLE=$(echo "${STATUS}" | grep -o '"consoleRole":"[A-Z]*"' | tail -1 | grep -o '[A-Z]*"' | tr -d '"')
-          echo "admin-1 role in status: ${ADMIN1_ROLE}"
-          CODE=$(curl -sk -o /dev/null -w '%{http_code}' \
-            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
-          echo "admin-1 heartbeat?checkActive=true: HTTP ${CODE}"
-          if test "${CODE}" != "200"; then
-            echo "FAIL: admin-1 heartbeat returned ${CODE}, expected 200 (active)"
-            exit 1
-          fi
-          CODE0=$(curl -sk -o /dev/null -w '%{http_code}' \
-            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
+          echo "Waiting for admin-0 pod to be Ready again..."
+          kubectl wait pod "${PF_ADMIN_PRIVATE_HOSTNAME}-0" --for=condition=Ready --timeout=600s
+          echo "admin-0 is Ready."
+
+    - name: 06-wait-for-admin-0-reachable
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          URL="https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping"
+          echo "Waiting for admin-0 to be reachable after restart: ${URL}"
+          i=0
+          while test "${i}" -lt 300; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 2 "${URL}" 2>/dev/null)
+            if test "${CODE}" = "200" || test "${CODE}" = "403"; then
+              echo "PASS: admin-0 is reachable (HTTP ${CODE})"
+              exit 0
+            fi
+            echo "${i}: Response: ${CODE}"
+            sleep 2
+            i=$((i + 1))
+          done
+          echo "FAIL: admin-0 did not become reachable within timeout"
+          exit 1
+
+    - name: 07-assert-admin-1-still-active
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          CODE1=$(curl -sk -o /dev/null -w '%{http_code}' "https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
+          echo "admin-1 heartbeat?checkActive=true: HTTP ${CODE1}"
+          CODE0=$(curl -sk -o /dev/null -w '%{http_code}' "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true")
           echo "admin-0 heartbeat?checkActive=true: HTTP ${CODE0}"
+          if test "${CODE1}" != "200"; then
+            echo "FAIL: admin-1 returned ${CODE1}, expected 200 (active)"
+            exit 1
+          fi
           if test "${CODE0}" != "403"; then
-            echo "FAIL: admin-0 heartbeat returned ${CODE0}, expected 403 (passive)"
+            echo "FAIL: admin-0 returned ${CODE0}, expected 403 (passive)"
             exit 1
           fi
           echo "PASS: admin-1 is active (200), admin-0 is passive (403)"

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-single.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-single.yaml
@@ -9,9 +9,13 @@
 pingfederate-admin:
   enabled: true
   envs:
-    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: getting-started/pingfederate
     OPERATIONAL_MODE: CLUSTERED_CONSOLE
+    CREATE_INITIAL_ADMIN_USER: "true"
+  workload:
+    type: StatefulSet
+    statefulSet:
+      persistentvolume:
+        enabled: false
   container:
     replicaCount: 1
     resources:
@@ -41,7 +45,7 @@ testFramework:
         - "900"
 
     - name: 02-assert-no-cluster-query-log
-      image: bitnami/kubectl:latest
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-single.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-single.yaml
@@ -1,0 +1,54 @@
+###############################################################################
+# Ping Identity Test - PingFederate Multi-Admin: Single-Admin Regression
+#
+# Variation 1 (intel) / Variation 2 (arm)
+# Asserts that a single-admin deployment is unaffected by the hook changes:
+#   - Admin pod reaches /pingfederate/app
+#   - Hook 81 did NOT emit cluster-query log lines
+###############################################################################
+pingfederate-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingfederate
+    OPERATIONAL_MODE: CLUSTERED_CONSOLE
+  container:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+
+###############################################################################
+# Test Steps
+###############################################################################
+testFramework:
+  enabled: true
+  testConfigMaps:
+    files:
+      - wait-for-url.sh
+
+  testSteps:
+    - name: 01-wait-for-admin
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - /var/run/wait-for-url.sh
+        - https://${PF_ADMIN_PRIVATE_HOSTNAME}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pingfederate/app
+        - "900"
+
+    - name: 02-assert-no-cluster-query-log
+      image: bitnami/kubectl:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          POD="${PF_ADMIN_PRIVATE_HOSTNAME}-0"
+          if kubectl logs "${POD}" | grep -q "Querying cluster for existing active admin node"; then
+            echo "FAIL: cluster-query log line present in single-admin deployment"
+            exit 1
+          fi
+          echo "PASS: no cluster-query log lines in single-admin deployment"

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-two-node.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-two-node.yaml
@@ -1,0 +1,83 @@
+###############################################################################
+# Ping Identity Test - PingFederate Multi-Admin: Two-Node Cluster
+#
+# Variation 1 (intel) / Variation 2 (arm)
+# Asserts correct initial deploy and restart-loop behavior:
+#   - admin-0 reaches active state (heartbeat 200)
+#   - admin-1 exits passive without restart loops (RESTARTS=0 after 5 min)
+#   - Cluster API reports exactly 1 ACTIVE and 1 PASSIVE
+###############################################################################
+pingfederate-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingfederate
+    OPERATIONAL_MODE: CLUSTERED_CONSOLE
+    PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "true"
+  workload:
+    type: StatefulSet
+    statefulSet:
+      podManagementPolicy: OrderedReady
+      persistentvolume:
+        enabled: false
+  container:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+
+###############################################################################
+# Test Steps
+###############################################################################
+testFramework:
+  enabled: true
+  testConfigMaps:
+    files:
+      - wait-for-url.sh
+
+  testSteps:
+    - name: 01-wait-for-admin-0-active
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - /var/run/wait-for-url.sh
+        - https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true
+        - "900"
+
+    - name: 02-assert-cluster-roles
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          STATUS=$(curl -sk -u "administrator:${PING_IDENTITY_PASSWORD}" \
+            -H "X-XSRF-Header: PingFederate" \
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/status")
+          ACTIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"ACTIVE"' | wc -l | tr -d ' ')
+          PASSIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"PASSIVE"' | wc -l | tr -d ' ')
+          echo "Active nodes: ${ACTIVE}  Passive nodes: ${PASSIVE}"
+          if test "${ACTIVE}" != "1" || test "${PASSIVE}" != "1"; then
+            echo "FAIL: expected 1 ACTIVE + 1 PASSIVE, got ACTIVE=${ACTIVE} PASSIVE=${PASSIVE}"
+            echo "${STATUS}"
+            exit 1
+          fi
+          echo "PASS: cluster has 1 ACTIVE and 1 PASSIVE"
+
+    - name: 03-assert-admin-1-no-restarts
+      image: bitnami/kubectl:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          RESTARTS=$(kubectl get pod "${PF_ADMIN_PRIVATE_HOSTNAME}-1" \
+            -o jsonpath='{.status.containerStatuses[0].restartCount}')
+          echo "admin-1 restart count: ${RESTARTS}"
+          if test "${RESTARTS}" != "0"; then
+            echo "FAIL: admin-1 has restarted ${RESTARTS} time(s)"
+            exit 1
+          fi
+          echo "PASS: admin-1 restart count is 0"

--- a/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-two-node.yaml
+++ b/helm-tests/integration-tests/pf-multi-admin/pf-multi-admin-two-node.yaml
@@ -4,15 +4,22 @@
 # Variation 1 (intel) / Variation 2 (arm)
 # Asserts correct initial deploy and restart-loop behavior:
 #   - admin-0 reaches active state (heartbeat 200)
-#   - admin-1 exits passive without restart loops (RESTARTS=0 after 5 min)
 #   - Cluster API reports exactly 1 ACTIVE and 1 PASSIVE
+#   - admin-1 has RESTARTS=0 (no restart loop)
+#
+# Pod DNS:  <pod>.<release>-pingfederate-cluster  (headless service)
+# PF_ADMIN_PRIVATE_HOSTNAME = <release>-pingfederate-admin
+# Headless svc              = <release>-pingfederate-cluster
 ###############################################################################
+global:
+  envs:
+    PING_IDENTITY_PASSWORD: 2FederateM0re
+
 pingfederate-admin:
   enabled: true
   envs:
-    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: getting-started/pingfederate
     OPERATIONAL_MODE: CLUSTERED_CONSOLE
+    CREATE_INITIAL_ADMIN_USER: "true"
     PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "true"
   workload:
     type: StatefulSet
@@ -44,19 +51,55 @@ testFramework:
       image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
-        - /var/run/wait-for-url.sh
-        - https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true
-        - "900"
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          URL="https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping?checkActive=true"
+          echo "Waiting for active admin-0: ${URL}"
+          i=0
+          while test "${i}" -lt 900; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 2 "${URL}" 2>/dev/null)
+            if test "${CODE}" = "200"; then echo "PASS: admin-0 is active"; exit 0; fi
+            echo "${i}: Response: ${CODE}"
+            sleep 2
+            i=$((i + 1))
+          done
+          echo "FAIL: admin-0 did not become active within timeout"
+          exit 1
 
-    - name: 02-assert-cluster-roles
+    - name: 02-wait-for-admin-1-passive
       image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c
         - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
+          URL="https://${PF_ADMIN_PRIVATE_HOSTNAME}-1.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf/heartbeat.ping"
+          echo "Waiting for admin-1 to be reachable: ${URL}"
+          i=0
+          while test "${i}" -lt 450; do
+            CODE=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 2 "${URL}" 2>/dev/null)
+            if test "${CODE}" = "200" || test "${CODE}" = "403"; then
+              echo "PASS: admin-1 is reachable (HTTP ${CODE})"
+              exit 0
+            fi
+            echo "${i}: Response: ${CODE}"
+            sleep 2
+            i=$((i + 1))
+          done
+          echo "FAIL: admin-1 did not become reachable within timeout"
+          exit 1
+
+    - name: 03-assert-cluster-roles
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          CLUSTER_SVC=$(echo "${PF_ADMIN_PRIVATE_HOSTNAME}" | sed 's/-admin$/-cluster/')
           STATUS=$(curl -sk -u "administrator:${PING_IDENTITY_PASSWORD}" \
             -H "X-XSRF-Header: PingFederate" \
-            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${PF_ADMIN_PRIVATE_HOSTNAME}-cluster:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/status")
+            "https://${PF_ADMIN_PRIVATE_HOSTNAME}-0.${CLUSTER_SVC}:${PF_ADMIN_PRIVATE_PORT_HTTPS}/pf-admin-api/v1/cluster/status")
           ACTIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"ACTIVE"' | wc -l | tr -d ' ')
           PASSIVE=$(echo "${STATUS}" | grep -o '"consoleRole":"PASSIVE"' | wc -l | tr -d ' ')
           echo "Active nodes: ${ACTIVE}  Passive nodes: ${PASSIVE}"
@@ -67,8 +110,8 @@ testFramework:
           fi
           echo "PASS: cluster has 1 ACTIVE and 1 PASSIVE"
 
-    - name: 03-assert-admin-1-no-restarts
-      image: bitnami/kubectl:latest
+    - name: 04-assert-admin-1-no-restarts
+      image: ${DEPS_REGISTRY}pingidentity/pingtoolkit:latest
       command:
         - /bin/sh
         - -c

--- a/pingfederate/opt/staging/hooks/81-after-start-process.sh
+++ b/pingfederate/opt/staging/hooks/81-after-start-process.sh
@@ -12,102 +12,102 @@
 # Non-zero ordinal nodes exit passive immediately, skipping both 83 and 85.
 # Ordinal-0 proceeds to run 83 (creates admin credentials), then queries
 # cluster status to handle the restart-after-failover case.
-if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
-    && test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
+if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" &&
+	test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
 
-    _pod_ordinal=$(echo "${HOSTNAME:-}" | sed 's/.*-//')
-    if echo "${_pod_ordinal}" | grep -qE '^[0-9]+$' && test "${_pod_ordinal}" != "0"; then
-        echo "INFO: Pod ordinal ${_pod_ordinal} — this is a passive admin node. Skipping configuration hooks."
-        exit 0
-    fi
-    if ! echo "${_pod_ordinal}" | grep -qE '^[0-9]+$'; then
-        echo "INFO: Non-numeric pod ordinal (${_pod_ordinal}) — staying passive. StatefulSet with ordinal hostnames is required for multi-admin."
-        exit 0
-    fi
-    # Ordinal 0 falls through to hook 83 below.
+	_pod_ordinal=$(hostname | sed 's/.*-//')
+	if echo "${_pod_ordinal}" | grep -qE '^[0-9]+$' && test "${_pod_ordinal}" != "0"; then
+		echo "INFO: Pod ordinal ${_pod_ordinal} — this is a passive admin node. Skipping configuration hooks."
+		exit 0
+	fi
+	if ! echo "${_pod_ordinal}" | grep -qE '^[0-9]+$'; then
+		echo "INFO: Non-numeric pod ordinal (${_pod_ordinal}) — staying passive. StatefulSet with ordinal hostnames is required for multi-admin."
+		exit 0
+	fi
+	# Ordinal 0 falls through to hook 83 below.
 fi
 
 # check if admin password is to be changed by looking for an 'initial' password
 if test -f "${BULK_CONFIG_DIR}/${BULK_CONFIG_FILE}" || test "$(toLower "${CREATE_INITIAL_ADMIN_USER}")" = "true"; then
-    run_hook 83-configure-admin.sh
+	run_hook 83-configure-admin.sh
 fi
 
 # After 83, admin credentials exist. Now check cluster status to determine
 # whether to promote (first start) or stay passive (restart after failover).
-if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
-    && test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
+if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" &&
+	test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
 
-    _pf_admin_password="$(get_value PING_IDENTITY_PASSWORD true)"
-    if test -z "${_pf_admin_password}"; then
-        echo_yellow "WARN: No PING_IDENTITY_PASSWORD variable found. Using default password."
-        _pf_admin_password="2Federate"
-    fi
+	_pf_admin_password="$(get_value PING_IDENTITY_PASSWORD true)"
+	if test -z "${_pf_admin_password}"; then
+		echo_yellow "WARN: No PING_IDENTITY_PASSWORD variable found. Using default password."
+		_pf_admin_password="2Federate"
+	fi
 
-    echo "INFO: Querying cluster for existing active admin node..."
-    _statusCode=$(
-        curl --insecure --silent \
-            --write-out '%{http_code}' --output /tmp/cluster.status \
-            --user "${ROOT_USER}:${_pf_admin_password}" \
-            --header 'X-XSRF-Header: PingFederate' \
-            "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/status" \
-            2>/dev/null
-    )
+	echo "INFO: Querying cluster for existing active admin node..."
+	_statusCode=$(
+		curl --insecure --silent \
+			--write-out '%{http_code}' --output /tmp/cluster.status \
+			--user "${ROOT_USER}:${_pf_admin_password}" \
+			--header 'X-XSRF-Header: PingFederate' \
+			"https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/status" \
+			2>/dev/null
+	)
 
-    if test "${_statusCode}" = "200"; then
-        _activeCount=$(jq -r '[.nodes[]? | select(.adminConsoleInfo.consoleRole == "ACTIVE")] | length' /tmp/cluster.status 2>/dev/null)
-        _activeCount="${_activeCount:-0}"
-    else
-        echo "WARN: Could not query cluster status (HTTP ${_statusCode}). Assuming no active admin."
-        _activeCount="0"
-    fi
+	if test "${_statusCode}" = "200"; then
+		_activeCount=$(jq -r '[.nodes[]? | select(.adminConsoleInfo.consoleRole == "ACTIVE")] | length' /tmp/cluster.status 2>/dev/null)
+		_activeCount="${_activeCount:-0}"
+	else
+		echo "WARN: Could not query cluster status (HTTP ${_statusCode}). Assuming no active admin."
+		_activeCount="0"
+	fi
 
-    if test "${_activeCount}" != "0"; then
-        # Active admin already exists — pod-0 restarted after a failover to another node.
-        echo "INFO: Active admin already present in cluster. This node will remain passive."
-        echo "INFO: Passive admin node — skipping bulk config import."
-        exit 0
-    fi
+	if test "${_activeCount}" != "0"; then
+		# Active admin already exists — pod-0 restarted after a failover to another node.
+		echo "INFO: Active admin already present in cluster. This node will remain passive."
+		echo "INFO: Passive admin node — skipping bulk config import."
+		exit 0
+	fi
 
-    echo "INFO: No active admin in cluster. Promoting this node to active."
-    # The promote endpoint takes no request body.
-    _promoteCode=$(
-        curl --insecure --silent \
-            --request POST \
-            --write-out '%{http_code}' --output /tmp/promote.out \
-            --user "${ROOT_USER}:${_pf_admin_password}" \
-            --header 'X-XSRF-Header: PingFederate' \
-            "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/adminNode/role/active" \
-            2>/dev/null
-    )
-    if test "${_promoteCode}" != "200"; then
-        echo_red "ERROR ${_promoteCode}: Failed to promote this node to active admin."
-        cat /tmp/promote.out
-        exit 81
-    fi
-    echo "INFO: This node has been promoted to active admin."
+	echo "INFO: No active admin in cluster. Promoting this node to active."
+	# The promote endpoint takes no request body.
+	_promoteCode=$(
+		curl --insecure --silent \
+			--request POST \
+			--write-out '%{http_code}' --output /tmp/promote.out \
+			--user "${ROOT_USER}:${_pf_admin_password}" \
+			--header 'X-XSRF-Header: PingFederate' \
+			"https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/adminNode/role/active" \
+			2>/dev/null
+	)
+	if test "${_promoteCode}" != "200"; then
+		echo_red "ERROR ${_promoteCode}: Failed to promote this node to active admin."
+		cat /tmp/promote.out
+		exit 81
+	fi
+	echo "INFO: This node has been promoted to active admin."
 
-    # Wait for the promotion to take effect before bulk import.
-    # Active node responds 200; passive responds 403.
-    echo "INFO: Waiting for active promotion to take effect..."
-    _maxWait=30
-    _waited=0
-    while test "${_waited}" -lt "${_maxWait}"; do
-        _checkCode=$(curl --insecure --silent --write-out '%{http_code}' --output /dev/null \
-            "https://localhost:${PF_ADMIN_PORT}/pf/heartbeat.ping?checkActive=true" 2>/dev/null)
-        if test "${_checkCode}" = "200"; then
-            echo "INFO: Node confirmed active (heartbeat responded 200)."
-            break
-        fi
-        sleep 2
-        _waited=$(( _waited + 2 ))
-    done
-    if test "${_waited}" -ge "${_maxWait}"; then
-        echo_red "ERROR: Node did not confirm active state within ${_maxWait}s after promotion."
-        exit 81
-    fi
+	# Wait for the promotion to take effect before bulk import.
+	# Active node responds 200; passive responds 403.
+	echo "INFO: Waiting for active promotion to take effect..."
+	_maxWait=30
+	_waited=0
+	while test "${_waited}" -lt "${_maxWait}"; do
+		_checkCode=$(curl --insecure --silent --write-out '%{http_code}' --output /dev/null \
+			"https://localhost:${PF_ADMIN_PORT}/pf/heartbeat.ping?checkActive=true" 2>/dev/null)
+		if test "${_checkCode}" = "200"; then
+			echo "INFO: Node confirmed active (heartbeat responded 200)."
+			break
+		fi
+		sleep 2
+		_waited=$((_waited + 2))
+	done
+	if test "${_waited}" -ge "${_maxWait}"; then
+		echo_red "ERROR: Node did not confirm active state within ${_maxWait}s after promotion."
+		exit 81
+	fi
 fi
 
 # check for bulk config import file
 if test -f "${BULK_CONFIG_DIR}/${BULK_CONFIG_FILE}"; then
-    run_hook 85-import-configuration.sh
+	run_hook 85-import-configuration.sh
 fi

--- a/pingfederate/opt/staging/hooks/81-after-start-process.sh
+++ b/pingfederate/opt/staging/hooks/81-after-start-process.sh
@@ -9,6 +9,99 @@ if test -f "${BULK_CONFIG_DIR}/${BULK_CONFIG_FILE}" || test "$(toLower "${CREATE
     run_hook 83-configure-admin.sh
 fi
 
+# When active/passive multi-admin is enabled, determine if this node should
+# run the bulk config import or defer to synchronization from the active node.
+#
+# This block runs after 83-configure-admin.sh so admin credentials exist for
+# the API calls, but before 85-import-configuration.sh so import only runs
+# on the active node.
+if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
+    && test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
+
+    _pf_admin_password="$(get_value PING_IDENTITY_PASSWORD true)"
+    if test -z "${_pf_admin_password}"; then
+        echo_yellow "WARN: No PING_IDENTITY_PASSWORD variable found. Using default password."
+        _pf_admin_password="2Federate"
+    fi
+
+    # Always query cluster status first to detect an existing active admin.
+    # This correctly handles pod-0 restarts after a failover to pod-1.
+    echo "INFO: Querying cluster for existing active admin node..."
+    _statusCode=$(
+        curl --insecure --silent \
+            --write-out '%{http_code}' --output /tmp/cluster.status \
+            --user "${ROOT_USER}:${_pf_admin_password}" \
+            --header 'X-XSRF-Header: PingFederate' \
+            "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/status" \
+            2>/dev/null
+    )
+
+    if test "${_statusCode}" = "200"; then
+        _activeCount=$(jq -r '[.nodes[]? | select(.adminConsoleInfo.consoleRole == "ACTIVE")] | length' /tmp/cluster.status 2>/dev/null)
+        _activeCount="${_activeCount:-0}"
+    else
+        echo "WARN: Could not query cluster status (HTTP ${_statusCode}). Assuming no active admin."
+        _activeCount="0"
+    fi
+
+    if test "${_activeCount}" != "0"; then
+        # An active admin already exists in the cluster — this node stays passive.
+        # This covers: pod-0 restarting after failover, or pod-N joining an established cluster.
+        echo "INFO: Active admin already present in cluster. This node will remain passive."
+        echo "INFO: Passive admin node — skipping bulk config import."
+        exit 0
+    fi
+
+    # No active admin found. Use pod ordinal as tiebreaker:
+    # ordinal 0 promotes; any other ordinal stays passive and waits for pod-0.
+    _pod_ordinal=$(echo "${HOSTNAME:-}" | sed 's/.*-//')
+    if echo "${_pod_ordinal}" | grep -qE '^[0-9]+$' && test "${_pod_ordinal}" = "0"; then
+        echo "INFO: No active admin in cluster and pod ordinal is 0. Promoting this node to active."
+    else
+        echo "INFO: No active admin in cluster but pod ordinal is not 0 (${_pod_ordinal}). Staying passive; pod-0 will promote."
+        echo "INFO: Passive admin node — skipping bulk config import."
+        exit 0
+    fi
+
+    # Promote this node to active.
+    # The promote endpoint takes no request body.
+    _promoteCode=$(
+        curl --insecure --silent \
+            --request POST \
+            --write-out '%{http_code}' --output /tmp/promote.out \
+            --user "${ROOT_USER}:${_pf_admin_password}" \
+            --header 'X-XSRF-Header: PingFederate' \
+            "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/cluster/adminNode/role/active" \
+            2>/dev/null
+    )
+    if test "${_promoteCode}" != "200"; then
+        echo_red "ERROR ${_promoteCode}: Failed to promote this node to active admin."
+        cat /tmp/promote.out
+        exit 81
+    fi
+    echo "INFO: This node has been promoted to active admin."
+
+    # Wait for the promotion to take effect before proceeding with bulk import.
+    # Passive nodes respond 403 to checkActive=true; active nodes respond 200.
+    echo "INFO: Waiting for active promotion to take effect..."
+    _maxWait=30
+    _waited=0
+    while test "${_waited}" -lt "${_maxWait}"; do
+        _checkCode=$(curl --insecure --silent --write-out '%{http_code}' --output /dev/null \
+            "https://localhost:${PF_ADMIN_PORT}/pf/heartbeat.ping?checkActive=true" 2>/dev/null)
+        if test "${_checkCode}" = "200"; then
+            echo "INFO: Node confirmed active (heartbeat responded 200)."
+            break
+        fi
+        sleep 2
+        _waited=$(( _waited + 2 ))
+    done
+    if test "${_waited}" -ge "${_maxWait}"; then
+        echo_red "ERROR: Node did not confirm active state within ${_maxWait}s after promotion."
+        exit 81
+    fi
+fi
+
 # check for bulk config import file
 if test -f "${BULK_CONFIG_DIR}/${BULK_CONFIG_FILE}"; then
     run_hook 85-import-configuration.sh

--- a/pingfederate/opt/staging/hooks/81-after-start-process.sh
+++ b/pingfederate/opt/staging/hooks/81-after-start-process.sh
@@ -4,17 +4,36 @@
 # shellcheck source=../../../../pingcommon/opt/staging/hooks/pingcommon.lib.sh
 . "${HOOKS_DIR}/pingcommon.lib.sh"
 
+# When active/passive multi-admin is enabled, determine role BEFORE calling
+# hook 83 — the license agreement endpoint (used by 83) returns 403 on a
+# passive node, which would cause a container failure.
+#
+# Decision: use pod ordinal as the initial active/passive split on first start.
+# Non-zero ordinal nodes exit passive immediately, skipping both 83 and 85.
+# Ordinal-0 proceeds to run 83 (creates admin credentials), then queries
+# cluster status to handle the restart-after-failover case.
+if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
+    && test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
+
+    _pod_ordinal=$(echo "${HOSTNAME:-}" | sed 's/.*-//')
+    if echo "${_pod_ordinal}" | grep -qE '^[0-9]+$' && test "${_pod_ordinal}" != "0"; then
+        echo "INFO: Pod ordinal ${_pod_ordinal} — this is a passive admin node. Skipping configuration hooks."
+        exit 0
+    fi
+    if ! echo "${_pod_ordinal}" | grep -qE '^[0-9]+$'; then
+        echo "INFO: Non-numeric pod ordinal (${_pod_ordinal}) — staying passive. StatefulSet with ordinal hostnames is required for multi-admin."
+        exit 0
+    fi
+    # Ordinal 0 falls through to hook 83 below.
+fi
+
 # check if admin password is to be changed by looking for an 'initial' password
 if test -f "${BULK_CONFIG_DIR}/${BULK_CONFIG_FILE}" || test "$(toLower "${CREATE_INITIAL_ADMIN_USER}")" = "true"; then
     run_hook 83-configure-admin.sh
 fi
 
-# When active/passive multi-admin is enabled, determine if this node should
-# run the bulk config import or defer to synchronization from the active node.
-#
-# This block runs after 83-configure-admin.sh so admin credentials exist for
-# the API calls, but before 85-import-configuration.sh so import only runs
-# on the active node.
+# After 83, admin credentials exist. Now check cluster status to determine
+# whether to promote (first start) or stay passive (restart after failover).
 if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
     && test "${OPERATIONAL_MODE}" = "CLUSTERED_CONSOLE"; then
 
@@ -24,8 +43,6 @@ if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
         _pf_admin_password="2Federate"
     fi
 
-    # Always query cluster status first to detect an existing active admin.
-    # This correctly handles pod-0 restarts after a failover to pod-1.
     echo "INFO: Querying cluster for existing active admin node..."
     _statusCode=$(
         curl --insecure --silent \
@@ -45,25 +62,13 @@ if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
     fi
 
     if test "${_activeCount}" != "0"; then
-        # An active admin already exists in the cluster — this node stays passive.
-        # This covers: pod-0 restarting after failover, or pod-N joining an established cluster.
+        # Active admin already exists — pod-0 restarted after a failover to another node.
         echo "INFO: Active admin already present in cluster. This node will remain passive."
         echo "INFO: Passive admin node — skipping bulk config import."
         exit 0
     fi
 
-    # No active admin found. Use pod ordinal as tiebreaker:
-    # ordinal 0 promotes; any other ordinal stays passive and waits for pod-0.
-    _pod_ordinal=$(echo "${HOSTNAME:-}" | sed 's/.*-//')
-    if echo "${_pod_ordinal}" | grep -qE '^[0-9]+$' && test "${_pod_ordinal}" = "0"; then
-        echo "INFO: No active admin in cluster and pod ordinal is 0. Promoting this node to active."
-    else
-        echo "INFO: No active admin in cluster but pod ordinal is not 0 (${_pod_ordinal}). Staying passive; pod-0 will promote."
-        echo "INFO: Passive admin node — skipping bulk config import."
-        exit 0
-    fi
-
-    # Promote this node to active.
+    echo "INFO: No active admin in cluster. Promoting this node to active."
     # The promote endpoint takes no request body.
     _promoteCode=$(
         curl --insecure --silent \
@@ -81,8 +86,8 @@ if test "$(toLower "${PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED}")" = "true" \
     fi
     echo "INFO: This node has been promoted to active admin."
 
-    # Wait for the promotion to take effect before proceeding with bulk import.
-    # Passive nodes respond 403 to checkActive=true; active nodes respond 200.
+    # Wait for the promotion to take effect before bulk import.
+    # Active node responds 200; passive responds 403.
     echo "INFO: Waiting for active promotion to take effect..."
     _maxWait=30
     _waited=0

--- a/pingfederate/opt/staging/hooks/83-configure-admin.sh
+++ b/pingfederate/opt/staging/hooks/83-configure-admin.sh
@@ -8,63 +8,63 @@
 start_debug_logging
 ## attempt to accept license, works if new server, fails if admin exists.
 _acceptLicenseAgreement=$(
-    curl \
-        --insecure \
-        --silent \
-        --request PUT \
-        --write-out '%{http_code}' \
-        --output /tmp/license.acceptance \
-        --header "X-XSRF-Header: PingFederate" \
-        --header 'Content-Type: application/json' \
-        --data '{"accepted":true}' \
-        "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/license/agreement" \
-        2> /dev/null
+	curl \
+		--insecure \
+		--silent \
+		--request PUT \
+		--write-out '%{http_code}' \
+		--output /tmp/license.acceptance \
+		--header "X-XSRF-Header: PingFederate" \
+		--header 'Content-Type: application/json' \
+		--data '{"accepted":true}' \
+		"https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/license/agreement" \
+		2>/dev/null
 )
 # Toggle off debug logging
 stop_debug_logging
 
 case "${_acceptLicenseAgreement}" in
-    200)
-        # This is a new PingFederate instance, then create admin user.
-        echo "INFO: new server found, must create admin"
+200)
+	# This is a new PingFederate instance, then create admin user.
+	echo "INFO: new server found, must create admin"
 
-        # Make sure PING_IDENTITY_PASSWORD is defined
-        test -z "${PING_IDENTITY_PASSWORD}" && container_failure 83 "ERROR: PING_IDENTITY_PASSWORD is not defined. Could not create administrator user."
+	# Make sure PING_IDENTITY_PASSWORD is defined
+	test -z "${PING_IDENTITY_PASSWORD}" && container_failure 83 "ERROR: PING_IDENTITY_PASSWORD is not defined. Could not create administrator user."
 
-        # Toggle on debug logging if DEBUG=true is set
-        start_debug_logging
-        # Set script vars
-        admin_roles='["ADMINISTRATOR","USER_ADMINISTRATOR","CRYPTO_ADMINISTRATOR","EXPRESSION_ADMINISTRATOR","DATA_COLLECTION_ADMINISTRATOR"]'
-        _createAdminUser=$(
-            curl \
-                --insecure \
-                --silent \
-                --write-out '%{http_code}' \
-                --output /tmp/create.admin \
-                --request POST \
-                --header "X-XSRF-Header: PingFederate" \
-                --header 'Content-Type: application/json' \
-                --data '{"username": "administrator", "password": "'"${PING_IDENTITY_PASSWORD}"'",
+	# Toggle on debug logging if DEBUG=true is set
+	start_debug_logging
+	# Set script vars
+	admin_roles='["ADMINISTRATOR","USER_ADMINISTRATOR","CRYPTO_ADMINISTRATOR","EXPRESSION_ADMINISTRATOR","DATA_COLLECTION_ADMINISTRATOR"]'
+	_createAdminUser=$(
+		curl \
+			--insecure \
+			--silent \
+			--write-out '%{http_code}' \
+			--output /tmp/create.admin \
+			--request POST \
+			--header "X-XSRF-Header: PingFederate" \
+			--header 'Content-Type: application/json' \
+			--data '{"username": "administrator", "password": "'"${PING_IDENTITY_PASSWORD}"'",
           "description": "Initial administrator user.", 
           "auditor": false,"active": true, 
           "roles": '"${admin_roles}"' }' \
-                "https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/administrativeAccounts" \
-                2> /dev/null
-        )
-        # Toggle off debug logging
-        stop_debug_logging
-        if test "${_createAdminUser}" != "200"; then
-            echo_red "$(jq -r . /tmp/create.admin)"
-            echo_red "error attempting to create admin"
-            exit 83
-        fi
-        ;;
-    401)
-        echo "INFO: Found existing admin PingFederate instance. Skipping creation of new admin user."
-        ;;
-    *)
-        echo_red "$(jq -r . /tmp/license.acceptance)"
-        echo_red "License Agreement Failed"
-        exit 83
-        ;;
+			"https://localhost:${PF_ADMIN_PORT}/pf-admin-api/v1/administrativeAccounts" \
+			2>/dev/null
+	)
+	# Toggle off debug logging
+	stop_debug_logging
+	if test "${_createAdminUser}" != "200"; then
+		echo_red "$(jq -r . /tmp/create.admin)"
+		echo_red "error attempting to create admin"
+		exit 83
+	fi
+	;;
+401)
+	echo "INFO: Found existing admin PingFederate instance. Skipping creation of new admin user."
+	;;
+*)
+	echo_red "$(jq -r . /tmp/license.acceptance)"
+	echo_red "License Agreement Failed"
+	exit 83
+	;;
 esac

--- a/pingfederate/opt/staging/hooks/83-configure-admin.sh
+++ b/pingfederate/opt/staging/hooks/83-configure-admin.sh
@@ -34,12 +34,7 @@ case "${_acceptLicenseAgreement}" in
         # Toggle on debug logging if DEBUG=true is set
         start_debug_logging
         # Set script vars
-        # TODO Remove if-else logic when PF 12.1 is no longer built
-        if test "$(isImageVersionGtEq 12.2.0)" -eq "0"; then
-            admin_roles='["ADMINISTRATOR","USER_ADMINISTRATOR","CRYPTO_ADMINISTRATOR","EXPRESSION_ADMINISTRATOR","DATA_COLLECTION_ADMINISTRATOR"]'
-        else
-            admin_roles='["ADMINISTRATOR","USER_ADMINISTRATOR","CRYPTO_ADMINISTRATOR","EXPRESSION_ADMINISTRATOR"]'
-        fi
+        admin_roles='["ADMINISTRATOR","USER_ADMINISTRATOR","CRYPTO_ADMINISTRATOR","EXPRESSION_ADMINISTRATOR","DATA_COLLECTION_ADMINISTRATOR"]'
         _createAdminUser=$(
             curl \
                 --insecure \

--- a/pingfederate/opt/staging/hooks/83-configure-admin.sh
+++ b/pingfederate/opt/staging/hooks/83-configure-admin.sh
@@ -62,6 +62,9 @@ case "${_acceptLicenseAgreement}" in
 401)
 	echo "INFO: Found existing admin PingFederate instance. Skipping creation of new admin user."
 	;;
+403)
+	echo "INFO: License already accepted on this cluster. Skipping admin configuration."
+	;;
 *)
 	echo_red "$(jq -r . /tmp/license.acceptance)"
 	echo_red "License Agreement Failed"


### PR DESCRIPTION
# PDI-1891 Implementation Plan: Active/Passive Multi-Admin Support in PingFederate Image Hooks

## Problem Statement

When `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED=true`, PingFederate starts all admin nodes in `PASSIVE` mode by default. The current hook sequence is:

```
80-post-start.sh  →  81-after-start-process.sh  →  83-configure-admin.sh  →  85-import-configuration.sh
```

`83-configure-admin.sh` succeeds on a passive node (license acceptance and admin-user creation both work). But `85-import-configuration.sh` issues `POST /pf-admin-api/v1/bulk/import` which the PF API rejects with **HTTP 403** on a passive node. The pod then enters a restart loop.

The fix must:
1. Promote exactly one admin node to active before config import runs.
2. Skip config import on passive nodes (the sync mechanism delivers config to them automatically).
3. Not promote a restarting pod-0 when another active already exists.
4. Require no external tooling or changes to the Helm chart to take effect.

---

## Root Cause: Hook Execution Flow

```
81-after-start-process.sh (current)
│
├─ if data.json exists OR CREATE_INITIAL_ADMIN_USER=true
│    └─ run_hook 83-configure-admin.sh      ← succeeds on PASSIVE (200 license, user created)
│
└─ if data.json exists
     └─ run_hook 85-import-configuration.sh ← FAILS on PASSIVE (403 bulk/import)
```

The fix inserts active/passive promotion logic **after 83 completes** (so the admin user credential exists for the API calls) and **before 85 runs** (so the import only targets an active node).

## Solution Design

### Key API Endpoints

| Endpoint | Method | Body | Purpose |
|---|---|---|---|
| `/pf-admin-api/v1/cluster/status` | GET | none | Returns all cluster nodes with `adminConsoleInfo.consoleRole` (ACTIVE/PASSIVE) |
| `/pf-admin-api/v1/cluster/adminNode/role/active` | POST | none | Promotes this node to active (no request body) |
| `/pf/heartbeat.ping?checkActive=true` | GET | none | Returns 200 if active, 403 if passive |

Note: the promote endpoint takes **no request body**. The `-d ''` and `Content-Type: application/json` header should both be omitted — passing a Content-Type without a body is non-standard and may be rejected by strict API implementations.

### Node Role Determination — Decision Order

**Always query cluster status first. Ordinal is only a tiebreaker when no active exists.**

This prevents a restarting pod-0 from unconditionally demoting a pod-1 that was promoted during a prior failover.

Non-StatefulSet (Deployment) mode is explicitly not supported for multi-admin. If `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED=true` is set with a Deployment workload, pods will have non-ordinal hostnames and all will start passive. This is a safe failure — no runaway promotions — but the feature simply won't work without a StatefulSet. The Helm chart work in PDI-2256 enforces StatefulSet when `multiAdmin.enabled: true`.

### Files Changed

| File | Change type |
|---|---|
| `pingfederate/opt/staging/hooks/81-after-start-process.sh` | Modified — core fix |
| `pingfederate/opt/staging/hooks/83-configure-admin.sh` | Minor cleanup — remove dead PF 12.1 version gate |

---

## Behavior Matrix

| Scenario | `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED` | Node | Expected Result |
|---|---|---|---|
| Standard single-admin | `false` or unset | any | Existing behavior unchanged — 83 + 85 run normally |
| Multi-admin, initial deploy, first pod | `true` | admin-0 (ordinal 0) | Cluster query returns 0 active → promoted → 83 + 85 run |
| Multi-admin, initial deploy, second pod | `true` | admin-1 (ordinal 1) | Cluster query returns 1 active → passive → skip 85, exit 0 |
| Multi-admin, admin-0 restarts (admin-1 is active) | `true` | admin-0 | Cluster query returns 1 active → passive → skip 85, exit 0 |
| Multi-admin, admin-1 restarts (admin-0 is active) | `true` | admin-1 | Cluster query returns 1 active → passive → skip 85, exit 0 |
| Multi-admin, all pods restart simultaneously | `true` | admin-0 wins | StatefulSet sequential start: admin-0 starts, finds 0 active, promotes; admin-1 starts, finds 1 active, stays passive |
| Multi-admin, non-ordinal hostname (Deployment) | `true` | any | Cluster query runs; if active found → passive; if no active found → ordinal check fails (non-numeric) → passive; **no promotion occurs** — unsupported configuration |
| Explicit `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED=false` | `false` | any | New block not entered; unchanged behavior |

---

## Test Plan and Results

### Test 1: Single-Admin Regression (No Change in Behavior)

**Purpose**: Confirm the fix does not alter existing single-admin deployments.

**Setup:** `OPERATIONAL_MODE=CLUSTERED_CONSOLE`, no `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED`

**Results**:
| Check | Expected | Actual | Pass? |
|---|---|---|---|
| Container health | healthy | healthy | ✅ |
| Restart count | 0 | 0 | ✅ |
| Hook 83 ran | yes | `INFO: new server found, must create admin` | ✅ |
| Hook 85 ran | yes | `INFO: Removing Imported Bulk File` | ✅ |
| Multi-admin log lines | none | none | ✅ |
---

### Test 2: Multi-Admin — Two Replicas, Initial Deployment

**Purpose**: Core fix — admin-0 becomes active and imports config; admin-1 starts passive without restart-looping.

**Results**:
| Check | Expected | Actual | Pass? |
|---|---|---|---|
| admin-0 health | healthy | healthy | ✅ |
| admin-1 health | unhealthy (passive — checkActive=true→403) | unhealthy | ✅ |
| admin-0 restarts | 0 | 0 | ✅ |
| admin-1 restarts | 0 | 0 | ✅ |
| Cluster: ACTIVE count | 1 | 1 | ✅ |
| Cluster: PASSIVE count | 1 | 1 | ✅ |
| admin-1 ERROR 403 | absent | absent | ✅ |
---

### Test 3: Restart-Loop Check

**Purpose**: Confirm admin-1 does not restart after the fix.

**Results**:
Observed during Test 2 monitoring — admin-1 was checked every 15s for 5+ minutes.

| Check | Expected | Actual | Pass? |
|---|---|---|---|
| admin-1 RESTARTS=0 after 5+ min | 0 | 0 | ✅ |

---

### Test 4: Manual Failover (Promote Passive to Active)

**Purpose**: Confirm operator can promote admin-1 and cluster transitions cleanly.

**Results**:

| Check | Expected | Actual | Pass? |
|---|---|---|---|
| Promote API returns 200 + `{"warnings":[]}` | yes | yes | ✅ |
| admin-1 becomes ACTIVE | yes | yes | ✅ |
| admin-0 becomes PASSIVE | yes | yes | ✅ |
---

### Test 5: Pod-0 Restarts After Failover to Pod-1

**Purpose**: The critical regression test for the original logic bug. Admin-0 must NOT promote itself when admin-1 is already active.

**Precondition**: Test 4 complete — admin-1 is active, admin-0 is passive.

**Results**:
**Cluster state after admin-0 restart:**
```
172.21.0.3:7600  role=ACTIVE    ← admin-1 unchanged
172.21.0.2:7600  role=PASSIVE   ← admin-0 came back passive
```

| Check | Expected | Actual | Pass? |
|---|---|---|---|
| admin-0 does NOT self-promote | correct | passive path taken | ✅ |
| admin-1 remains ACTIVE | yes | yes | ✅ |
| admin-0 restarts | 0 | 0 | ✅ |
| `Promoting this node` NOT in admin-0 logs | absent | absent | ✅ |

---

### Test 6: Simultaneous Restart of All Admin Pods

**Purpose**: Confirm ordinal tiebreaker prevents split-brain on full rollout restart.

**Results**:
| Check | Expected | Actual | Pass? |
|---|---|---|---|
| Exactly 1 ACTIVE in cluster | 1 | 1 | ✅ |
| admin-0 restarts | 0 | 0 | ✅ |
| admin-1 restarts | 0 | 0 | ✅ |

**Note:** In Docker Compose, `docker restart` on both containers is truly simultaneous (no ordering guarantee). The cluster still converged to exactly 1 ACTIVE. The ordinal-0 tiebreaker and the cluster-status query together prevented split-brain.

---

### Test 7: Backward Compatibility — Flag Explicitly False

**Purpose**: `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "false"` has no effect on behavior.

**Setup**: Same as Test 1 but with `PF_CLUSTER_ADMIN_NODES_SYNC_ENABLED: "false"` set.

**Results**:
**Setup:** Same as T1 with flag explicitly set to false

| Check | Expected | Actual | Pass? |
|---|---|---|---|
| Container health | healthy | healthy | ✅ |
| Restart count | 0 | 0 | ✅ |
| Hook 83 ran | yes | `INFO: new server found, must create admin` | ✅ |
| Hook 85 ran | yes | `INFO: Removing Imported Bulk File` | ✅ |
| Multi-admin log lines | none | none | ✅ |

---

## Sources

- Hylton Leigh POC: https://docs.google.com/document/d/1ovx1dDQEKHbKk0QBXHshZNzhEFCbXDFD7gZfAlZIIZs
- PF API docs (active/passive endpoints): https://docs.pingidentity.com/pingfederate/12.3/server_clustering_guide/pf_active_passive_admin_console_endpoints.html
- Jira PDI-2256: https://pingidentity.atlassian.net/browse/PDI-2256
